### PR TITLE
removed row.first/lastname from alert message  to delete speech wihout assigned person

### DIFF
--- a/components/SpeechesList.vue
+++ b/components/SpeechesList.vue
@@ -128,8 +128,14 @@
         this.$store.dispatch('meetings/addSpeech', meetingId)
       },
       handleDelete(index, row) {
+        var txt = ""
+        if(row.person != null){
+          txt =  "Usunąć wystąpienie " + row.person.first_name + " " + row.person.last_name + "?"
+
+        }
         this.$swal({
             title: 'Czy jesteś pewny, że chcesz usunąć wystąpienie?',
+          text:txt,
             type: 'warning',
             showCancelButton: true,
             confirmButtonColor: '#d33',


### PR DESCRIPTION
Usuwanie wystąpienia bez osoby : 
Wystarczyło usunąć z komunikatu "Czy chcesz na pewno usunąć..." odwołanie do osoby, bo jej nie ma (dlatego był null)